### PR TITLE
Changes for integration with AWS Cognito

### DIFF
--- a/src/Indice.Kentico.Oidc/OAuthConfiguration.cs
+++ b/src/Indice.Kentico.Oidc/OAuthConfiguration.cs
@@ -12,7 +12,10 @@ namespace Indice.Kentico.Oidc
         public static string ClientId => ConfigurationManager.AppSettings["Oidc:ClientId"];
         public static string ClientSecret => ConfigurationManager.AppSettings["Oidc:ClientSecret"];
         public static string[] Scopes => ConfigurationManager.AppSettings["Oidc:Scopes"]?.Split(' ') ?? Array.Empty<string>();
-        public static string UserNameClaim => ConfigurationManager.AppSettings["Oidc:UserNameClaim"] = JwtClaimTypes.Name; 
+        public static string ResponseType => ConfigurationManager.AppSettings["Oidc:ResponseType"];
+        public static string UserNameClaim => ConfigurationManager.AppSettings["Oidc:UserNameClaim"] ?? "username"; 
         public static string AuthorizeEndpointPath => ConfigurationManager.AppSettings["Oidc:AuthorizeEndpointPath"]?.TrimStart('/') ?? "connect/authorize";
+        public static string TokenEndpointPath => ConfigurationManager.AppSettings["Oidc:TokenEndpointPath"]?.TrimStart('/') ?? "connect/authorize";
+        public static string UserInfoEndpointPath => ConfigurationManager.AppSettings["Oidc:UserInfoEndpointPath"]?.TrimStart('/') ?? "connect/authorize";
     }
 }

--- a/src/Indice.Kentico.Oidc/OidcAuthenticationModule.cs
+++ b/src/Indice.Kentico.Oidc/OidcAuthenticationModule.cs
@@ -2,6 +2,7 @@
 using IdentityModel;
 using IdentityModel.Client;
 using System;
+using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Principal;
@@ -27,16 +28,17 @@ namespace Indice.Kentico.Oidc
             var stateProvider = new StateProvider<string>();
             var currentPath = returnUrl ?? string.Empty;
             var requestUrl = new RequestUrl(authorizeEndpoint);
+
             // Create the url to Identity Server's authorize endpoint.
             var authorizeUrl = requestUrl.CreateAuthorizeUrl(
                 clientId: OAuthConfiguration.ClientId,
-                responseType: OidcConstants.ResponseTypes.CodeIdToken, // Requests an authorization code and identity token.
-                responseMode: OidcConstants.ResponseModes.FormPost, // Sends the token response as a form post instead of a fragment encoded redirect.
+                responseType: (OAuthConfiguration.ResponseType == "CodeIdToken")? OidcConstants.ResponseTypes.CodeIdToken : OidcConstants.ResponseTypes.Code, 
                 redirectUri: $"{OAuthConfiguration.Host}/SignInOidc.ashx",
                 nonce: Guid.NewGuid().ToString(), // Identity Server will echo back the nonce value in the identity token (this is for replay protection).
                 scope: OAuthConfiguration.Scopes.Join(" "),
                 state: stateProvider.CreateState(currentPath)
             );
+
             if (!HttpContext.Current.Response.IsRequestBeingRedirected) {
                 // Redirect the user to the authority.
                 HttpContext.Current.Response.Redirect(authorizeUrl);


### PR DESCRIPTION
Hello,

We are attempting to use AWS Cognito as our identity provider. Cognito doesn't support the hybrid "code id_token", only authorization code or token flows. I have made changes to get the project to work with Cognito (using the authorization code flow). In the process, I added a few more OAuthConfiguration options for configurability. The code still supports the "code id_token" response_type based on a an OAuthConfiguration option. Here is an example of my web.config configuration:

    <add key="Oidc:AutoRedirect" value="false" />
    <add key="Oidc:Authority" value="https://epuio.auth.us-east-2.amazoncognito.com" />
    <add key="Oidc:Host" value="https://test.equio.com/Kentico12" />
    <add key="Oidc:ClientId" value="********" />
    <add key="Oidc:ClientSecret" value="********" />
    <add key="Oidc:Scopes" value="openid profile" />
    <add key="Oidc:AuthorizeEndpointPath" value="authorize" /> 
    <add key="Oidc:TokenEndpointPath" value="oauth2/token" /> 
    <add key="Oidc:UserInfoEndpointPath" value="oauth2/userInfo" /> 
    <add key="Oidc:ResponseType" value="Code" /> <!-- Allowed values: "Code" or "CodeIdToken" -->
    <add key="Oidc:UserNameClaim" value="username" /> <!-- The name of the claim returned by the IDP that uniquely identifies the user -->

I encountered an error where I had to change "SiteContext.CurrentSite.SiteID" to "SiteContext.CurrentSiteID". Not sure why.

I hope these changes are helpful. I would appreciate any feedback you may have.

Paul